### PR TITLE
Add option lastparlineminlength

### DIFF
--- a/impnattypo-test.tex
+++ b/impnattypo-test.tex
@@ -1,14 +1,19 @@
 \documentclass{scrbook}
 
-\usepackage[draft,
-            nosingleletter,
-            lastparline,
-            nosinglelettercolor=green,
-            lastparlinecolor=blue]{impnattypo}
+\usepackage[%
+  draft,
+  nosingleletter,
+  lastparline,
+  nosinglelettercolor=green,
+  lastparlinecolor=blue,
+  lastparlineminlength=2cm
+]{impnattypo}
 \usepackage[french]{babel} %language selection
 
 \usepackage{fontspec}
 \setmainfont{Linux Libertine O}
+
+\usepackage{enumitem}
 
 \begin{document}
 
@@ -17,10 +22,27 @@ Je sais bien qu'il y a peu de
 gens qui y vont à reculons.
 }
 
+\vspace{3cm}
+
+\begin{minipage}{5cm}
+  zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz
+
+  \begin{itemize}
+  \item zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz
+  \item zzz zzz zzz zzz zzz zzz zzz zzz
+  \item zzz zzz zzz zzz zzz zzz zzz
+  \end{itemize}
+\end{minipage}
 
 \vspace{3cm}
 
-\parindent = 2cm
+\ifluatex
+  \parindent = 2cm
+  \setlength{\lastparlineminlength}{0.5\linewidth}
+\else
+  \parindent = 5cm
+  \the\parfillskip
+\fi
 
 A wonderful serenity has taken possession of my entire soul, like these sweet mornings of spring which I enjoy with my whole heart. I am alone, and feel.
 

--- a/impnattypo.dtx
+++ b/impnattypo.dtx
@@ -57,7 +57,7 @@
 %</driver>
 % \fi
 %
-% \CheckSum{121}
+% \CheckSum{138}
 %
 % \CharacterTable
 %  {Upper-case    \A\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z
@@ -239,7 +239,9 @@
 % When \LuaTeX{} is used, the solution provided by Patrick Gundlach\footnote{\url{http://tex.stackexchange.com/questions/28357/ensure-minimal-length-of-last-line/28361\#28361}}
 % is used. With other rendering engines, it is the native solution provided by
 % Enrico Gregorio\footnote{\url{http://tex.stackexchange.com/questions/28357/ensure-minimal-length-of-last-line/28358\#28358}}
-% that serves as an implementation:
+% that serves as an implementation. The option \texttt{lastparlineminlength}
+% allows to set, for the last line of a paragaph, a minimal length greater (but
+% not smaller) than its default (|2\parindent|):
 % \else
 % De plus, il est indiqué dans la section \og Coupure des mots \fg{}
 % que \og la dernière ligne d'un alinéa doit comporter un mot ou
@@ -252,19 +254,29 @@
 % Lorsque \LuaTeX{} est utilisé, la solution de Patrick Gundlach\footnote{\url{http://tex.stackexchange.com/questions/28357/ensure-minimal-length-of-last-line/28361\#28361}}
 % est utilisée. Avec les autres moteurs de rendu, c'est la solution native de
 % Enrico Gregorio\footnote{\url{http://tex.stackexchange.com/questions/28357/ensure-minimal-length-of-last-line/28358\#28358}}
-% qui fait office d'implémentation:
+% qui fait office d'implémentation. L'option \texttt{lastparlineminlength}
+% permet de choisir, pour la dernière ligne de l'alinéa, une longueur minimale
+% supérieure (mais pas inférieure) à sa valeur par défaut (|2\parindent|) :
 % \fi
 %
 % \begin{verbatim}
-%    \usepackage[lastparline]{impnattypo}
+%    \usepackage[lastparline, lastparlineminlength=3em]{impnattypo}
 % \end{verbatim}
 %
 % \ifenglish
+% \noindent With \LuaTeX{}, the value given to the option \texttt{lastparlineminlength} is
+% stored in the length |\lastparlineminlength|, which can be modified later, within
+% the document.
+%
 % When the \texttt{draft} option is activated and \LuaTeX{} is used,
 % the inserted ties are colored in
 % {\color{\intlastparlinecolor}\intlastparlinecolor}.
 % The color can be tuned with the \texttt{lastparlinecolor} option.
 % \else
+% \noindent Avec \LuaLaTeX{}, la valeur passée à l'option \texttt{lastparlineminlength}
+% est stockée dans la longueur |\lastparlineminlength|, qui peut être modifée
+% ultérieurement, dans le document.
+%
 % Lorsque l'option \texttt{draft} est activée et que \LuaTeX{} est utilisé,
 % les espaces insécables insérés sont colorés en
 % {\color{\intlastparlinecolor}\intlastparlinecolor}.

--- a/impnattypo.dtx
+++ b/impnattypo.dtx
@@ -569,6 +569,7 @@
 \DeclareStringOption[lime]{riverscolor}
 \DeclareStringOption[1]{homeoarchymaxwords}
 \DeclareStringOption[3]{homeoarchymaxchars}
+\DeclareStringOption[0pt]{lastparlineminlength}
 \ProcessKeyvalOptions*
 \RequirePackage{xcolor}
 \def\usecolor#1{\csname\string\color@#1\endcsname\space}
@@ -659,18 +660,22 @@
 %    \begin{macrocode}
 \ifintlastparline
    \ifluatex
+      \newlength{\lastparlineminlength}
+      \setlength{\lastparlineminlength}{\intlastparlineminlength}
       \RequirePackage{luatexbase,luacode}
       \begin{luacode}
       local glyph_id = node.id "glyph"
       local glue_id  = node.id "glue"
       local hlist_id = node.id "hlist"
 
-      last_line_twice_parindent = function (head)
+      last_line_minimal_length = function (head)
         while head do
           local _w,_h,_d = node.dimensions(head)
-          if head.id == glue_id and head.subtype ~= 15 and (_w < 2 * tex.parindent) then
+          if head.id == glue_id and head.subtype ~= 15
+            and (_w < 2 * tex.parindent or _w < tex.skip['lastparlineminlength'].width)
+          then
 
-              -- we are at a glue and have less then 2*\parindent to go
+              -- we are at a glue and have less then 2*\parindent of \lastparlineminlength to go
               local p = node.new("penalty")
               p.penalty = 10000
 
@@ -690,10 +695,14 @@
         return true
       end
 
-      luatexbase.add_to_callback("pre_linebreak_filter",last_line_twice_parindent,"lastparline")
+      luatexbase.add_to_callback("pre_linebreak_filter",last_line_minimal_length,"lastparline")
       \end{luacode}
    \else
-      \setlength{\parfillskip}{0pt plus\dimexpr\textwidth-2\parindent}
+      \setlength{\@tempskipa}{\intlastparlineminlength}
+      \ifdim\@tempskipa < 2\parindent
+        \setlength{\@tempskipa}{2\parindent}
+      \fi
+      \setlength{\parfillskip}{0pt plus\dimexpr\textwidth-\@tempskipa}
    \fi
 \fi
 %    \end{macrocode}


### PR DESCRIPTION
With `LuaLaTeX`, the option `lastparline` works with the current value of `\parindent`. This means that it has no effect when `\parindent` in zero, for example:
 - in minipage;
 - in a list, if the package `enumitem` is also used.

See #12.

Moreover, it would be great to let the user choose a larger value, as requested in #5.

<br>

This pull request implement this, through the package option `lastparlineminlength`. The value given to `lastparlineminlength` is used as replacement to `2\parindent` only if larger, to assure a backward compatibility. The  implementation is done for `pdfLaTeX` and `LuaLaTeX`.

For `LuaLaTeX` this set and use the length `\lastparlineminlength` which can be directly modified by the user within the document.