### PR TITLE
Prevent hyphenations that break lastparline mechanism

### DIFF
--- a/impnattypo-test.tex
+++ b/impnattypo-test.tex
@@ -17,9 +17,17 @@
 
 \begin{document}
 
-\parbox{3cm}{
-Je sais bien qu'il y a peu de
-gens qui y vont à reculons.
+\parbox[t]{3cm}{
+  Je sais bien qu'il y a peu de gens qui y vont à reculons.
+}
+\hfill
+\parbox[t]{4cm}{
+  Je sais bien qu'il y a peu de gens qui y vont à reculons.
+}
+\hfill
+\parbox[t]{5cm}{
+  \parindent=2cm
+  Je sais bien qu'il y a peu de gens qui y vont à reculons.
 }
 
 \vspace{3cm}

--- a/impnattypo.dtx
+++ b/impnattypo.dtx
@@ -268,6 +268,8 @@
 % \noindent With \LuaTeX{}, the value given to the option \texttt{lastparlineminlength} is
 % stored in the length |\lastparlineminlength|, which can be modified later, within
 % the document.
+% Hyphenation is also suppressed near the end of the paragraph to prevent
+% hyphenation points from interfering with the minimal length constraint.
 %
 % When the \texttt{draft} option is activated and \LuaTeX{} is used,
 % the inserted ties are colored in
@@ -277,6 +279,8 @@
 % \noindent Avec \LuaLaTeX{}, la valeur passée à l'option \texttt{lastparlineminlength}
 % est stockée dans la longueur |\lastparlineminlength|, qui peut être modifée
 % ultérieurement, dans le document.
+% Les césures sont également supprimées en fin d'alinéa afin d'éviter
+% qu'un point de césure n'interfère avec la contrainte de longueur minimale.
 %
 % Lorsque l'option \texttt{draft} est activée et que \LuaTeX{} est utilisé,
 % les espaces insécables insérés sont colorés en
@@ -688,7 +692,7 @@
           if
             _w < 2 * tex.parindent or _w < tex.skip['lastparlineminlength'].width
           then
-            -- we have less then 2*\parindent of \lastparlineminlength to go
+            -- we have less than 2*\parindent or \lastparlineminlength to go
 
             if head.id == disc_id then
               -- we are at a discretionary: avoid hyphenations

--- a/impnattypo.dtx
+++ b/impnattypo.dtx
@@ -680,15 +680,23 @@
       local glyph_id = node.id "glyph"
       local glue_id  = node.id "glue"
       local hlist_id = node.id "hlist"
+      local disc_id  = node.id "disc"
 
       last_line_minimal_length = function (head)
         while head do
           local _w,_h,_d = node.dimensions(head)
-          if head.id == glue_id and head.subtype ~= 15
-            and (_w < 2 * tex.parindent or _w < tex.skip['lastparlineminlength'].width)
+          if
+            _w < 2 * tex.parindent or _w < tex.skip['lastparlineminlength'].width
           then
+            -- we have less then 2*\parindent of \lastparlineminlength to go
 
-              -- we are at a glue and have less then 2*\parindent of \lastparlineminlength to go
+            if head.id == disc_id then
+              -- we are at a discretionary: avoid hyphenations
+              head.penalty=10000
+            end
+
+            if head.id == glue_id and head.subtype ~= 15 then
+              -- we are at a glue: avoid line break
               local p = node.new("penalty")
               p.penalty = 10000
 
@@ -701,6 +709,8 @@
               \else
                  node.insert_after(head,head.prev,p)
               \fi
+            end
+
           end
 
           head = head.next


### PR DESCRIPTION
When the option `latparline` is used the last line of a paragraph should not be shorter than a given value. But if an hyphenation occurs this could fails.

This PR sets a large penalty for all discretionary points that are present at the end of the paragraph, to avoid hyphenations.